### PR TITLE
When logging assertions use the error level logging

### DIFF
--- a/wxPython/src/helpers.cpp
+++ b/wxPython/src/helpers.cpp
@@ -399,7 +399,7 @@ void wxPyApp::OnAssertFailure(const wxChar *file,
                 buf << wxT(" in ") << func << wxT("()");
             if (msg != NULL) 
                 buf << wxT(": ") << msg;
-            wxLogDebug(buf);
+            wxLogError(buf);
         }
 
         // do the normal wx assert dialog?


### PR DESCRIPTION
Debug level logging is not included in release builds, therefore the assert information is lost. So instead we log the assertions (when log assertions is set) at the error level.
